### PR TITLE
adjust apache-folder watcher

### DIFF
--- a/initscripts/apacheServiceListener.sh
+++ b/initscripts/apacheServiceListener.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 
-if ps aux | grep -v "grep" | grep "inotifywait -m /etc/apache2/sites-enabled -e delete -e create -e moved_to"
+MYWAIT="inotifywait -m /etc/apache2/sites-enabled -e delete -e create -e moved_to"
+
+if ps aux | grep -v "grep" | grep "$MYWAIT"
 then
     echo "Listener is still running"
     PID=$(pgrep inotifywait)
@@ -25,7 +27,7 @@ then
     done
     echo "Process has been killed after $count seconds."    
 fi
-if ps aux | grep -v "grep" | grep "inotifywait -m /etc/apache2/sites-enabled -e delete -e create -e moved_to"
+if ps aux | grep -v "grep" | grep "$MYWAIT"
 then
     echo "Listener is still running"
     PID=$(pgrep inotifywait)
@@ -51,8 +53,10 @@ then
     echo "Process has been killed after $count seconds."    
 fi
 
-inotifywait -m /etc/apache2/sites-enabled -e delete -e create -e moved_to |
+$MYWAIT |
     while read path action file; do
         echo "Folder /etc/apache2/sites-enabled changed: '$action' file '$file'"
         service apache2 reload
     done
+
+echo "The wait is finally over."

--- a/initscripts/apacheServiceListenerStop.sh
+++ b/initscripts/apacheServiceListenerStop.sh
@@ -11,6 +11,7 @@ if ps aux | grep -v "grep" | grep "$MYWAIT"
 then
     echo "Listener is still running"
     PID=$(pgrep -f "${bibboxinotifywait}")
+    #while echo kill $PID
     while kill $PID > /dev/null
         do
             # Wait for one second
@@ -36,6 +37,7 @@ if ps aux | grep -v "grep" | grep "$MYWAIT"
 then
     echo "Listener is still running"
     PID=$(pgrep -f "${bibboxinotifywait}")
+    #while echo kill $PID
     while kill $PID > /dev/null
         do
             # Wait for one second
@@ -57,11 +59,3 @@ then
     done
     echo "Process has been killed after $count seconds."
 fi
-
-echo "Starting process '$MYWAIT'"
-$MYWAIT |
-    while read path action file; do
-        echo "Folder /etc/apache2/sites-enabled changed: '$action' file '$file'"
-        service apache2 reload
-    done
-echo "Process '$MYWAIT' has ended."

--- a/initscripts/etc/bibbox/bibbox.cfg
+++ b/initscripts/etc/bibbox/bibbox.cfg
@@ -25,3 +25,7 @@ bibboxScriptUpdate="ON"
 for conffiles in /etc/bibbox/conf.d/*.cfg; do
   . $conffiles
 done
+
+# string for starting and stopping bibbox service
+bibboxinotifywait="inotifywait -m /etc/apache2/sites-enabled -e delete -e create -e moved_to"
+bibboxwaitseconds=5

--- a/initscripts/etc/init.d/bibbox
+++ b/initscripts/etc/init.d/bibbox
@@ -1,4 +1,15 @@
 #! /bin/bash
+### BEGIN INIT INFO
+# Provides: bibbox
+# Required-Start:
+# Should-Start:
+# Required-Stop:
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: bibbox service
+# Description: Start bibbox Service
+### END INIT INFO
+
 # /etc/init.d/bibbox
 #
 

--- a/initscripts/start.sh
+++ b/initscripts/start.sh
@@ -1,7 +1,6 @@
-#! /bin/bash
-
-echo "Start BIBBOX-VM Services"
+#!/bin/bash
+echo "Starting BIBBOX-VM Services"
 source /etc/bibbox/bibbox.cfg
 
-# Start Folder listener to restart apache2 when new config added
+# Start Folder listener that restarts apache2 when new configs are added
 . "$bibboxdir/$bibboxscriptfolder/initscripts/apacheServiceListener.sh" >> /var/log/apacheServiceListener.log 2>&1 &

--- a/initscripts/stop.sh
+++ b/initscripts/stop.sh
@@ -1,3 +1,6 @@
-#! /bin/sh
+#!/bin/bash
+echo "Stopping BIBBOX-VM Services"
+source /etc/bibbox/bibbox.cfg
 
-echo "stop.sh"
+# Stop Folder listener that has been restarting apache2 when new configs are added
+. "$bibboxdir/$bibboxscriptfolder/initscripts/apacheServiceListenerStop.sh" >> /var/log/apacheServiceListener.log 2>&1 &


### PR DESCRIPTION
To install kit-eb3kit on Ubuntu 18.04 LTS bionic, I needed to make a few adjustments to the apache2 inotifywait service.  If this PR can be approved and merged, then I can open a pr for kit-eb3kit.
I also refactored the code to both start the observed and observer processes with a single string drawn from the configuration file.

If there are changes to this PR that you would like made, please let me know.  Thank you for considering this PR.